### PR TITLE
Create separate continuous releases for each branch

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -2,7 +2,11 @@
 
 set +x # Do not leak information
 
-RELEASE_NAME="continuous" # Do not use "latest" as it is reserved by GitHub
+if [ -z "$TRAVIS_BRANCH" ] ; then
+	RELEASE_NAME="continuous" # Do not use "latest" as it is reserved by GitHub
+else
+	RELEASE_NAME="continuous-$TRAVIS_BRANCH" # not on master, so make it its own thing
+fi
 
 if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] ; then
   echo "Release uploading disabled for pull requests, uploading to transfer.sh instead"


### PR DESCRIPTION
The one in master stays 'continuous', the others have the branch name
attached.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>

This is super simplistic and may miss some obvious problems, but hey, I just started looking into this tool, so be nice :-)