### PR TITLE
Turn uploadtool into a more comprehensive release tool

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -68,7 +68,7 @@ if [ "$TRAVIS_COMMIT" != "$tag_sha" ] ; then
 
   echo "TRAVIS_COMMIT != tag_sha, hence deleting $RELEASE_NAME..."
   
-  if [ x"$release_id" != "x" ]; then
+  if [ ! -z "$release_id" ]; then
     delete_url="https://api.github.com/repos/$REPO_SLUG/releases/$release_id"
     echo "Delete the release..."
     echo "delete_url: $delete_url"

--- a/upload.sh
+++ b/upload.sh
@@ -2,7 +2,15 @@
 
 set +x # Do not leak information
 
-RELEASE_NAME="continuous" # Do not use "latest" as it is reserved by GitHub
+# The calling script (usually .travis.yml) can set a suffix to be used for
+# the tag and release name. This way it is possible to have a release for
+# the output of the CI/CD pipeline (marked as 'continuous') and also test
+# builds for other branches.
+if [ ! -z $UPLOADTOOL_SUFFIX ] ; then
+  RELEASE_NAME="continuous-$UPLOADTOOL_SUFFIX"
+else
+  RELEASE_NAME="continuous" # Do not use "latest" as it is reserved by GitHub
+fi
 
 if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] ; then
   echo "Release uploading disabled for pull requests, uploading to transfer.sh instead"

--- a/upload.sh
+++ b/upload.sh
@@ -8,8 +8,10 @@ set +x # Do not leak information
 # builds for other branches.
 if [ ! -z $UPLOADTOOL_SUFFIX ] ; then
   RELEASE_NAME="continuous-$UPLOADTOOL_SUFFIX"
+  RELEASE_TITLE="Continuous build ($UPLOADTOOL_SUFFIX)"
 else
   RELEASE_NAME="continuous" # Do not use "latest" as it is reserved by GitHub
+  RELEASE_TITLE="Continuous build"
 fi
 
 if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] ; then
@@ -100,7 +102,7 @@ if [ "$TRAVIS_COMMIT" != "$tag_sha" ] ; then
   fi
 
   release_infos=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
-       --data '{"tag_name": "'"$RELEASE_NAME"'","target_commitish": "'"$TRAVIS_BRANCH"'","name": "'"Continuous build"'","body": "'"$BODY"'","draft": false,"prerelease": true}' "https://api.github.com/repos/$REPO_SLUG/releases")
+       --data '{"tag_name": "'"$RELEASE_NAME"'","target_commitish": "'"$TRAVIS_BRANCH"'","name": "'"$RELEASE_TITLE"'","body": "'"$BODY"'","draft": false,"prerelease": true}' "https://api.github.com/repos/$REPO_SLUG/releases")
 
   echo "$release_infos"
 

--- a/upload.sh
+++ b/upload.sh
@@ -116,6 +116,11 @@ if [ "$TRAVIS_COMMIT" != "$tag_sha" ] ; then
 
 fi # if [ "$TRAVIS_COMMIT" != "$tag_sha" ]
 
+if [ -z "$release_url" ] ; then
+	echo "Cannot figure out the release URL for $RELEASE_NAME"
+	exit 1
+fi
+
 echo "Upload binaries to the release..."
 
 for FILE in $@ ; do

--- a/upload.sh
+++ b/upload.sh
@@ -111,7 +111,7 @@ if [ "$TRAVIS_COMMIT" != "$tag_sha" ] ; then
   fi
 
   release_infos=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
-       --data '{"tag_name": "'"$RELEASE_NAME"'","target_commitish": "'"$TRAVIS_BRANCH"'","name": "'"$RELEASE_TITLE"'","body": "'"$BODY"'","draft": false,"prerelease": '$is_prerelease'}' "https://api.github.com/repos/$REPO_SLUG/releases")
+       --data '{"tag_name": "'"$RELEASE_NAME"'","target_commitish": "'"$TRAVIS_COMMIT"'","name": "'"$RELEASE_TITLE"'","body": "'"$BODY"'","draft": false,"prerelease": '$is_prerelease'}' "https://api.github.com/repos/$REPO_SLUG/releases")
 
   echo "$release_infos"
 

--- a/upload.sh
+++ b/upload.sh
@@ -91,12 +91,16 @@ if [ "$TRAVIS_COMMIT" != "$tag_sha" ] ; then
   # curl -XGET --header "Authorization: token ${GITHUB_TOKEN}" \
   #     "$release_url"
 
-  echo "Delete the tag..."
-  delete_url="https://api.github.com/repos/$REPO_SLUG/git/refs/tags/$RELEASE_NAME"
-  echo "delete_url: $delete_url"
-  curl -XDELETE \
-      --header "Authorization: token ${GITHUB_TOKEN}" \
-      "${delete_url}"
+  if [ "$is_prerelease" = "true" ] ; then
+    # if this is a continuous build tag, then delete the old tag
+    # in preparation for the new release
+    echo "Delete the tag..."
+    delete_url="https://api.github.com/repos/$REPO_SLUG/git/refs/tags/$RELEASE_NAME"
+    echo "delete_url: $delete_url"
+    curl -XDELETE \
+        --header "Authorization: token ${GITHUB_TOKEN}" \
+        "${delete_url}"
+  fi
 
   echo "Create release..."
 


### PR DESCRIPTION
This does a few things
(1) allow the user of the tool to add a suffix to the tag / release name (so you can do your CI builds for your main branch, but also have test builds for feature development branches)
(2) make the titles of those releases a little more meaningful
(3) while we are at it, simply do releases for tags as well - I see no benefit in doing this through the 'deploy:' state of Travis - all that means is two places to have a key, two places that try to do releases, worst of all, possible inconsistencies between your CI releases and your 'real' releases. And as a side benefit, it all looks consistent and somewhat logical