### PR TITLE
Update the documentation and make release messages confugurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Super simple uploading of continuous builds (each push) to GitHub Releases. If t
 
 ## Usage
 
-Upon each run, this script will _delete_ any pre-existing release and tag with the name `continuous`, create a new one, and upload the specified binaries there.
+This script is designed to be called from Travis CI after a successful build. By default this script will _delete_ any pre-existing release and tag the current state with the name `continuous`, create a new a new release with that name, and upload the specified binaries there. For pull requests it will upload the binaries to transfer.sh instead and post the resulting download URL to the pull request page on GitHub.
 
  - On https://github.com/settings/tokens, click on "Generate new token" and generate a token with at least the `public_repo`, `repo:status`, and `repo_deployment` scopes
  - On Travis CI, go to the settings of your project at `https://travis-ci.org/yourusername/yourrepository/settings`

--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ One possible use case for this is to set up continuous builds for feature or tes
   fi
 ```
 This will create builds tagged with `continuous` for pushes / merges to `master` and with `continuous-<branch-name>` for pushes / merges to other branches.
+
+The two environment variables UPLOADTOOL_PR_BODY and UPLOADTOOL_BODY allow the calling script to customize the messages that are posted either for pull requests or merges / pushes. If these variables aren't set, generic default texts are used.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ branches:
     - # Do not build tags that we create when we upload to GitHub Releases
     - /^(?i:continuous)$/
 ```
+
+## Environment variables
+
+`upload.sh` normally only creates one stream of continuous releases for the latest commits that are pushed into (or merged into) the repository.
+
+It's possible to use `upload.sh` in a more complex manner by setting the environment variable `UPLOADTOOL_SUFFIX`. If this variable is set to the name of the current tag, then `upload.sh` will upload a release to the repository (basically reproducing the `deploy:` feature in `.travis.yml`).
+
+If `UPLOADTOOL_SUFFIX` is set to a different text, then this text is used as suffix for the `continuous` tag that is created for continuous releases. This way a project can customize what releases are being created.
+One possible use case for this is to set up continuous builds for feature or test branches:
+```
+  if [ ! -z $TRAVIS_BRANCH ] && [ "$TRAVIS_BRANCH" != "master" ] ; then
+    export UPLOADTOOL_SUFFIX=$TRAVIS_BRANCH
+  fi
+```
+This will create builds tagged with `continuous` for pushes / merges to `master` and with `continuous-<branch-name>` for pushes / merges to other branches.

--- a/upload.sh
+++ b/upload.sh
@@ -39,7 +39,11 @@ if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] ; then
     cat ./uploaded-to
     echo ""
     review_url="https://api.github.com/repos/${TRAVIS_REPO_SLUG}/pulls/${TRAVIS_PULL_REQUEST}/reviews"
-    body="Travis CI has created build artifacts for this PR here: $(cat ./uploaded-to)\nThis link will expire 14 days from now."
+    if [ ! -z $UPLOADTOOL_PR_BODY ] ; then
+      body="Travis CI has created build artifacts for this PR here: $(cat ./uploaded-to)\nThis link will expire 14 days from now."
+    else
+      body="$UPLOADTOOL_PR_BODY"
+    fi
     curl -X POST \
       --header "Authorization: token ${GITHUB_TOKEN}" \
       --data '{"commit_id": "'"$TRAVIS_COMMIT"'","body": "'"$body"'","event": "COMMENT"}' \
@@ -124,7 +128,11 @@ if [ "$TRAVIS_COMMIT" != "$tag_sha" ] ; then
   fi
 
   if [ ! -z "$TRAVIS_JOB_ID" ] ; then
-    BODY="Travis CI build log: https://travis-ci.org/$REPO_SLUG/builds/$TRAVIS_BUILD_ID/"
+    if [ ! -z $UPLOADTOOL_BODY ] ; then
+      BODY="Travis CI build log: https://travis-ci.org/$REPO_SLUG/builds/$TRAVIS_BUILD_ID/"
+    else
+      BODY="$UPLOADTOOL_BODY"
+    fi
   else
     BODY=""
   fi


### PR DESCRIPTION
As requested in #14 this improves the documentation in the README.md
It also adds two more variables to control the messages posted for releases and when uploading pull request artifacts to transfer.sh