### PR TITLE
If there are no arguments, there's nothing to do

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -2,6 +2,11 @@
 
 set +x # Do not leak information
 
+if [ $# -eq 0 ]; then
+    echo "No artifacts to use for release, giving up."
+    exit 0
+fi
+
 if command -v sha256sum >/dev/null 2>&1 ; then
   shatool="sha256sum"
 elif command -v shasum >/dev/null 2>&1 ; then


### PR DESCRIPTION
It doesn't make sense to create a release with no binaries. This often
happens if Travis CI actually failed, but for some reason the build
didn't error out before upload.sh is called.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>