### PR TITLE
Add code to be more verbose when review comment fails

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -44,10 +44,13 @@ if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] ; then
     else
       body="$UPLOADTOOL_PR_BODY"
     fi
-    curl -X POST \
+    review_comment=$(curl -X POST \
       --header "Authorization: token ${GITHUB_TOKEN}" \
       --data '{"commit_id": "'"$TRAVIS_COMMIT"'","body": "'"$body"'","event": "COMMENT"}' \
-      $review_url
+      $review_url)
+    if echo $review_comment | grep -q "Bad credentials" 2>/dev/null ; then
+      echo '"Bad credentials" response for --data {"commit_id": "'"$TRAVIS_COMMIT"'","body": "'"$body"'","event": "COMMENT"}'
+    fi
   done
   $shatool $@
   exit 0


### PR DESCRIPTION
This is untested as I am running out of time here - the idea should be obvious, but I'm worried if my quotation marks are correct. So please test this against a PR where you have seen upload.sh fail to post a comment...