### PR TITLE
fix UPLOADTOOL_BODY handling.

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -150,13 +150,14 @@ if [ "$TRAVIS_COMMIT" != "$target_commit_sha" ] ; then
   fi
 
   if [ ! -z "$TRAVIS_JOB_ID" ] ; then
-    if [ ! -z "$UPLOADTOOL_BODY" ] ; then
+    if [ -z "${UPLOADTOOL_BODY+x}" ] ; then
+      # TODO: The host could be travis-ci.org (legacy open source) or travis-ci.com (subscription or latest open source).
       BODY="Travis CI build log: https://travis-ci.org/$REPO_SLUG/builds/$TRAVIS_BUILD_ID/"
     else
       BODY="$UPLOADTOOL_BODY"
     fi
   else
-    BODY=""
+    BODY="$UPLOADTOOL_BODY"
   fi
 
   release_infos=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \


### PR DESCRIPTION
1. The logic for using UPLOADTOOL_BODY was inverted.  On travis setting UPLOADTOOL_BODY to a non-zero length string resulted in the default fixed body pointing to the travis build log.
2. Instead of testing for zero length, test to see if UPLOADTOOL_BODY is unset.  This allows for the user to substitute an empty body for the default body.
3. Use UPLOADTOOL_BODY when not building on travis.  If UPLOADTOOL_BODY is unset it should expand to "" so a test to see if it is unset is unnecessary.

Note that with the migration of open source projects to travis-ci.com the correct link could contain the host travis-ci.org (legacy open source) or travis-ci.com (migrated open source or subscription).  I don't know how to determine this and I have asked support@travis-ci.com.