### PR TITLE
Create releases using uploadtool

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -32,7 +32,7 @@ fi
 # If this build was triggered by a tag, call the result a Release
 if [ ! -z "$UPLOADTOOL_SUFFIX" ] ; then
   if [ "$UPLOADTOOL_SUFFIX" = "$TRAVIS_TAG" ] ; then
-    RELEASE_NAME=$TRAVIS_TAG
+    RELEASE_NAME="$TRAVIS_TAG"
     RELEASE_TITLE="Release build ($TRAVIS_TAG)"
     is_prerelease="false"
   else
@@ -41,9 +41,15 @@ if [ ! -z "$UPLOADTOOL_SUFFIX" ] ; then
     is_prerelease="true"
   fi
 else
-  RELEASE_NAME="continuous" # Do not use "latest" as it is reserved by GitHub
-  RELEASE_TITLE="Continuous build"
-  is_prerelease="true"
+  if [ "$TRAVIS_TAG" != "" ]; then
+    RELEASE_NAME="$TRAVIS_TAG"
+    RELEASE_TITLE="Release build ($TRAVIS_TAG)"
+    is_prerelease="false"
+  else
+    RELEASE_NAME="continuous" # Do not use "latest" as it is reserved by GitHub
+    RELEASE_TITLE="Continuous build"
+    is_prerelease="true"
+  fi
 fi
 
 if [ "$ARTIFACTORY_BASE_URL" != "" ]; then


### PR DESCRIPTION
Implements support for creating releases when tags are built. It's the exact same approach @dirkhh implemented for `$UPLOADTOOL_SUFFIX`. I was surprised this wasn't already implemented (@probonopd [this](https://github.com/AppImage/AppImageKit/issues/849#issuecomment-419611854) is _not_ the default use case).

Useful for https://github.com/TheAssassin/cura-type2-appimages/. Probably also useful for https://github.com/AppImage/AppImageKit/issues/849.