### PR TITLE
Updated readme text regarding escaping needed in UPLOADTOOL_*BODY

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ One possible use case for this is to set up continuous builds for feature or tes
 This will create builds tagged with `continuous` for pushes / merges to `master` and with `continuous-<branch-name>` for pushes / merges to other branches.
 
 The two environment variables `UPLOADTOOL_PR_BODY` and `UPLOADTOOL_BODY` allow the calling script to customize the messages that are posted either for pull requests or merges / pushes. If these variables aren't set, generic default texts are used.
+
+Note that `UPLOADTOOL*` variables will be used in bash script to form a JSON request, that means some
+characters like double quotes and new lines need to be escaped - example: `export UPLOADTOOL_BODY="\\\"Experimental\\\" version.\nDon't use this.\nTravis CI build log: https://travis-ci.com/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID/"`


### PR DESCRIPTION
I had a bit hard time figuring out why the artefacts are not uploading and later whats wrong with the create release json request. So I updated the readme, maybe it could help someone.

Also its a kind of hint how to solve the "travis-ci.org/travis-ci.com" problem, because for my repository the default upload text was pointing to wrong server.

Without escaping I always got
```
Create release...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   432  100   132  100   300    480   1092 --:--:-- --:--:-- --:--:--  1094
{
  "message": "Problems parsing JSON",
  "documentation_url": "https://developer.github.com/v3/repos/releases/#create-a-release"
}```