### PR TITLE
Use $TRAVIS_BUILD_WEB_URL as build log URL

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -207,7 +207,7 @@ if [ "$TRAVIS_COMMIT" != "$target_commit_sha" ] ; then
   if [ ! -z "$TRAVIS_JOB_ID" ] ; then
     if [ -z "${UPLOADTOOL_BODY+x}" ] ; then
       # TODO: The host could be travis-ci.org (legacy open source) or travis-ci.com (subscription or latest open source).
-      BODY="Travis CI build log: https://travis-ci.com/$REPO_SLUG/builds/$TRAVIS_BUILD_ID/"
+      BODY="Travis CI build log: $TRAVIS_BUILD_WEB_URL"
     else
       BODY="$UPLOADTOOL_BODY"
     fi


### PR DESCRIPTION
This fixes an issue wherein projects which are hosted on the legacy travis-ci.org platform does not specify an invalid url in their commit message. In these cases, the url would point to a non-existant log at the .com travis site.