### PR TITLE
Create prereleases for alpha/beta/RC tags

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -51,7 +51,7 @@ else
       ;;
     *-alpha*|*-beta*|*-rc*)
       RELEASE_NAME="$TRAVIS_TAG"
-      RELEASE_TITLE="Prerelease build ($TRAVIS_TAG)"
+      RELEASE_TITLE="Pre-release build ($TRAVIS_TAG)"
       is_prerelease="true"
       ;;
     *)

--- a/upload.sh
+++ b/upload.sh
@@ -41,15 +41,25 @@ if [ ! -z "$UPLOADTOOL_SUFFIX" ] ; then
     is_prerelease="true"
   fi
 else
-  if [ "$TRAVIS_TAG" != "" ]; then
-    RELEASE_NAME="$TRAVIS_TAG"
-    RELEASE_TITLE="Release build ($TRAVIS_TAG)"
-    is_prerelease="false"
-  else
-    RELEASE_NAME="continuous" # Do not use "latest" as it is reserved by GitHub
-    RELEASE_TITLE="Continuous build"
-    is_prerelease="true"
-  fi
+  # ,, is a bash-ism to convert variable to lower case
+  case "${TRAVIS_TAG,,}" in
+    "")
+      # Do not use "latest" as it is reserved by GitHub
+      RELEASE_NAME="continuous"
+      RELEASE_TITLE="Continuous build"
+      is_prerelease="true"
+      ;;
+    *-alpha*|*-beta*|*-rc*)
+      is_prerelease="true";
+      RELEASE_TITLE="Prerelease build ($TRAVIS_TAG)"
+      is_prerelease="true"
+      ;;
+    *)
+      RELEASE_NAME="$TRAVIS_TAG"
+      RELEASE_TITLE="Release build ($TRAVIS_TAG)"
+      is_prerelease="false"
+      ;;
+  esac
 fi
 
 if [ "$ARTIFACTORY_BASE_URL" != "" ]; then

--- a/upload.sh
+++ b/upload.sh
@@ -50,7 +50,7 @@ else
       is_prerelease="true"
       ;;
     *-alpha*|*-beta*|*-rc*)
-      is_prerelease="true";
+      RELEASE_NAME="$TRAVIS_TAG"
       RELEASE_TITLE="Prerelease build ($TRAVIS_TAG)"
       is_prerelease="true"
       ;;

--- a/upload.sh
+++ b/upload.sh
@@ -197,7 +197,7 @@ if [ "$TRAVIS_COMMIT" != "$target_commit_sha" ] ; then
   # curl -XGET --header "Authorization: token ${GITHUB_TOKEN}" \
   #     "$release_url"
 
-  if [ "$is_prerelease" = "true" ] ; then
+  if [ "$RELEASE_NAME" == "continuous" ] ; then
     # if this is a continuous build tag, then delete the old tag
     # in preparation for the new release
     echo "Delete the tag..."


### PR DESCRIPTION
I'm making prereleases for AppImageLauncher. I have two ways of doing this with uploadtool: Either I create the tag right away and have Travis build my binaries and create a new release for the tag on GitHub (and change it to prerelease after it finished), or I rename the continuous build and create a tag on the GitHub interface. The former is annoying since I have the risk of people thinking I created an actual release, which is not true and might lead to e.g., AppImageUpdate, downloading the new release and then downloading the old one on the next upldate. The latter is more annoying since I cannot build new commits until that `continuous` build has finished.

This PR introduces better support for prereleases. It searches the tag name for the typical strings you'd expect (`*-{alpha,beta,rc}*`, case insensitively) and if there's a match creates a prerelease instead.