### PR TITLE
Revert "Revert "Create prereleases for alpha/beta/RC tags""

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -41,15 +41,25 @@ if [ ! -z "$UPLOADTOOL_SUFFIX" ] ; then
     is_prerelease="true"
   fi
 else
-  if [ "$TRAVIS_TAG" != "" ]; then
-    RELEASE_NAME="$TRAVIS_TAG"
-    RELEASE_TITLE="Release build ($TRAVIS_TAG)"
-    is_prerelease="false"
-  else
-    RELEASE_NAME="continuous" # Do not use "latest" as it is reserved by GitHub
-    RELEASE_TITLE="Continuous build"
-    is_prerelease="true"
-  fi
+  # ,, is a bash-ism to convert variable to lower case
+  case "${TRAVIS_TAG,,}" in
+    "")
+      # Do not use "latest" as it is reserved by GitHub
+      RELEASE_NAME="continuous"
+      RELEASE_TITLE="Continuous build"
+      is_prerelease="true"
+      ;;
+    *-alpha*|*-beta*|*-rc*)
+      RELEASE_NAME="$TRAVIS_TAG"
+      RELEASE_TITLE="Pre-release build ($TRAVIS_TAG)"
+      is_prerelease="true"
+      ;;
+    *)
+      RELEASE_NAME="$TRAVIS_TAG"
+      RELEASE_TITLE="Release build ($TRAVIS_TAG)"
+      is_prerelease="false"
+      ;;
+  esac
 fi
 
 if [ "$ARTIFACTORY_BASE_URL" != "" ]; then
@@ -187,7 +197,7 @@ if [ "$TRAVIS_COMMIT" != "$target_commit_sha" ] ; then
   # curl -XGET --header "Authorization: token ${GITHUB_TOKEN}" \
   #     "$release_url"
 
-  if [ "$is_prerelease" = "true" ] ; then
+  if [ "$RELEASE_NAME" == "continuous" ] ; then
     # if this is a continuous build tag, then delete the old tag
     # in preparation for the new release
     echo "Delete the tag..."

--- a/upload.sh
+++ b/upload.sh
@@ -42,7 +42,7 @@ if [ ! -z "$UPLOADTOOL_SUFFIX" ] ; then
   fi
 else
   # ,, is a bash-ism to convert variable to lower case
-  case "${TRAVIS_TAG,,}" in
+  case $(tr '[:upper:]' '[:lower:]' <<< "$TRAVIS_TAG") in
     "")
       # Do not use "latest" as it is reserved by GitHub
       RELEASE_NAME="continuous"


### PR DESCRIPTION
Reverting blindly is such a crappy idea. The change was completely unrelated to the error... You could've seen yourself the message `"code": "already_exists",` is clearly some GitHub error message that doesn't make any sense in this context. uploadtool has been working fine so far.

Edit: also fixes #53.