### PR TITLE
Add security note regarding availability of GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This script is designed to be called from Travis CI after a successful build. By
 
  - On https://github.com/settings/tokens, click on "Generate new token" and generate a token with at least the `public_repo`, `repo:status`, and `repo_deployment` scopes
  - On Travis CI, go to the settings of your project at `https://travis-ci.com/yourusername/yourrepository/settings`
- - Under "Environment Variables", add key `GITHUB_TOKEN` and the token you generated above as the value. **Make sure that "Display value in build log" is set to "OFF"!**
+ - Under "Environment Variables", add key `GITHUB_TOKEN` and the token you generated above as the value. **Make sure that "Display value in build log" is set to "OFF"! Also make sure it is only available to your main branch (most of the time, `master`) to avoid leaking it and prevent uploads for any other branches!** 
  - In the `.travis.yml` of your GitHub repository, add something like this (assuming the build artifacts to be uploaded are in out/):
 
 ```yaml


### PR DESCRIPTION
There is a chance for third parties to be able to upload arbitrary files to your release page by sending you pull requests etc. which print out the variable value.

Also, it's a really simple way to prevent uploading files to continuous releases on branches other than `master`. If the credentials are simply not available, uploadtool cannot upload anything, right?