### PR TITLE
Fix bug with filenames that have spaces in them

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -255,6 +255,22 @@ fi
 
 echo "Upload binaries to the release..."
 
+# Need to URL encode the basename, so we have this function to do so
+urlencode() {
+  # urlencode <string>
+  old_lc_collate=$LC_COLLATE
+  LC_COLLATE=C
+  local length="${#1}"
+  for (( i = 0; i < length; i++ )); do
+    local c="${1:$i:1}"
+    case $c in
+      [a-zA-Z0-9.~_-]) printf '%s' "$c" ;;
+      *) printf '%%%02X' "'$c" ;;
+    esac
+  done
+  LC_COLLATE=$old_lc_collate
+}
+
 for FILE in "$@" ; do
   FULLNAME="${FILE}"
   BASENAME="$(basename "${FILE}")"
@@ -262,7 +278,7 @@ for FILE in "$@" ; do
        -H "Accept: application/vnd.github.manifold-preview" \
        -H "Content-Type: application/octet-stream" \
        --data-binary "@$FULLNAME" \
-       "$upload_url?name=$BASENAME"
+       "$upload_url?name=$(urlencode "$BASENAME")"
   echo ""
 done
 

--- a/upload.sh
+++ b/upload.sh
@@ -261,7 +261,7 @@ for FILE in "$@" ; do
   curl -H "Authorization: token ${GITHUB_TOKEN}" \
        -H "Accept: application/vnd.github.manifold-preview" \
        -H "Content-Type: application/octet-stream" \
-       --data-binary @$FULLNAME \
+       --data-binary "@$FULLNAME" \
        "$upload_url?name=$BASENAME"
   echo ""
 done


### PR DESCRIPTION
This pull request does the following:

- Adds quotes around the filename for cURL. This wasn't done before and caused any file with spaces in the name to immediately fail.
- URL encodes the basename. If this isn't done, the URL is considered invalid. This has to be done outside of cURL since it can't mix GET and POST parameters and the file has to be POST, therefore a minimal URL encode function has been added.

Together, this allows files with spaces (and probably other special characters too) that would fail before.